### PR TITLE
Allow parsing URLs and input ports

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -16,6 +16,8 @@ jobs:
         sudo: never
     - name: Install pkg and deps
       run: raco pkg install --batch --auto laramie-lib/ laramie-doc/ laramie-test/ laramie/
+    - name: Check for unnecessary dependencies
+      run: raco setup --check-pkg-deps laramie-lib
     - name: Run package-internal tests
       run: raco test -j 4 laramie-lib/
     - name: Run package-external tests

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Install pkg and deps
       run: raco pkg install --batch --auto laramie-lib/ laramie-doc/ laramie-test/ laramie/
     - name: Check for unnecessary dependencies
-      run: raco setup --check-pkg-deps laramie-lib
+      run: raco setup --check-pkg-deps laramie
     - name: Run package-internal tests
       run: raco test -j 4 laramie-lib/
     - name: Run package-external tests

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -10,7 +10,7 @@ jobs:
         architecture: 'x64'
         distribution: 'full'
         variant: "CS"
-        version: "8.4"
+        version: "8.6"
         local_catalogs: $GITHUB_WORKSPACE
         dest: '/opt/racketdist'
         sudo: never

--- a/laramie-lib/info.rkt
+++ b/laramie-lib/info.rkt
@@ -6,6 +6,7 @@
 (define authors '("jesse@serverracket.com"))
 (define deps '("base"
                "typed-racket-lib"
+               "typed-racket-more"
                "txexpr"
                "http-easy"))
 (define build-deps '("rackunit-lib"

--- a/laramie-lib/laramie/parser/parser.rkt
+++ b/laramie-lib/laramie/parser/parser.rkt
@@ -5,6 +5,7 @@
 (require racket/list
          racket/port
          racket/require
+         typed/net/url
          (file "types.rkt")
          (file "dom.rkt")
          (file "parameters.rkt")
@@ -2589,11 +2590,13 @@
   (unless (null? mode)
     (keep-parsing)))
 
-(: parse (-> (U String Bytes)
+(: parse (-> (U String Bytes URL Input-Port)
              document))
-(define (parse str)
-  (define in (cond [(string? str) (open-input-string str)]
-                   [else (open-input-bytes str)]))
+(define (parse thing)
+  (define in (cond [(string? thing) (open-input-string thing)]
+                   [(url? thing) (get-pure-port thing)]
+                   [(input-port? thing) thing]
+                   [else (open-input-bytes thing)]))
   (port-count-lines! in)
   (reset-parser-state!)
   (begin0

--- a/laramie-test/laramie/parser.rkt
+++ b/laramie-test/laramie/parser.rkt
@@ -18,7 +18,7 @@
                  0))
       (test-case
           (string-append test-name " [one DTD]")
-        (check-not-false (prolog-dtd p) 1)))))
+        (check-not-false (prolog-dtd p) "[parsing worked]")))))
 
 ; TODO (not close to working yet)
 #;


### PR DESCRIPTION
Given a URL, we naturally do an HTTP GET request for it. (No
security checks.) Input ports are naturally supported, since
`parse` is already set up to transform its argument into an
input port.